### PR TITLE
Don't use #eval to lookup adapter class

### DIFF
--- a/lib/backyard/configuration.rb
+++ b/lib/backyard/configuration.rb
@@ -43,11 +43,12 @@ module Backyard
 
     def adapter_klass
       adapter_name = adapter.to_s.split('_').map!{ |w| w.capitalize }.join
-      adapter_class = "Backyard::Adapter::#{adapter_name}"
-      unless eval("defined?(#{adapter_class}) && #{adapter_class}.is_a?(Class)") == true
+
+      unless Adapter.const_defined? adapter_name, false
         require File.join('backyard', 'adapter', "#{adapter}")
       end
-      eval adapter_class
+
+      Adapter.const_get adapter_name, false
     end
     private :adapter_klass
 


### PR DESCRIPTION
Because this might accidentally reference constants defined in global namespace (like FactoryGirl) which leads to the following error:

```
warning: toplevel constant FactoryGirl referenced by Backyard::Adapter::FactoryGirl
```

Finally! No more warnings in build logs... :joy_cat:
